### PR TITLE
Fix localfile name if labels are used

### DIFF
--- a/lib/bb/fetch2/perforce.py
+++ b/lib/bb/fetch2/perforce.py
@@ -103,22 +103,19 @@ class Perforce(FetchMethod):
     def urldata_init(self, ud, d):
         (host, path, user, pswd, parm) = Perforce.doparse(ud.url, d)
 
-        # If a label is specified, we use that as our filename
-
-        if "label" in parm:
-            ud.localfile = "%s.tar.gz" % (parm["label"])
-            return
-
         base = path
         which = path.find('/...')
         if which != -1:
-            base = path[:which-1]
+            base = path[:which]
 
         base = self._strip_leading_slashes(base)
+        
+        if "label" in parm:
+            version = parm["label"]
+        else:
+            version = Perforce.getcset(d, path, host, user, pswd, parm)
 
-        cset = Perforce.getcset(d, path, host, user, pswd, parm)
-
-        ud.localfile = data.expand('%s+%s+%s.tar.gz' % (host, base.replace('/', '.'), cset), d)
+        ud.localfile = data.expand('%s+%s+%s.tar.gz' % (host, base.replace('/', '.'), version), d)
 
     def download(self, ud, d):
         """


### PR DESCRIPTION
I could apply the label "release_1.0" to a super project that contains many sub projects.  If my recipes have SRC_URI's that use that label but grab different sub-folders, than there's a bug where the cached localfile (tar.gz) will not be unique and reused at the wrong times.

SRC_URI = "p4://perforce::1234@//depot/SuperProject/MiniProjectAAA/...;label=release_1.0 \
                     p4://perforce::1234@//depot/SuperProject/MiniProjectBBB/...;label=release_1.0"
