### PR TITLE
user-manual-metadata: Clarify functionality of task flag 'dirs'.

### DIFF
--- a/doc/bitbake-user-manual/bitbake-user-manual-metadata.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-metadata.xml
@@ -1233,7 +1233,9 @@
                     section for more information.
                     </para></listitem>
                 <listitem><para><emphasis>dirs:</emphasis>
-                    Directories that should be created before the task runs.
+                    Directories that should be created before the task runs. The
+                    last directory listed will be used as the work directory for the
+                    task.
                     </para></listitem>
                 <listitem><para><emphasis>lockfiles:</emphasis>
                      Specifies one or more lockfiles to lock while the task


### PR DESCRIPTION
Please consider this documentation update. I got stuck for a while not realizing 'dirs' have an effect on which work dir is used. This was extra confusing to me since 'cleandirs' is closely related, has very similar documentation, but differs in functionality as it does not seem to switch work directory.