### PR TITLE
Fix DocBook Issues in Documentation

### DIFF
--- a/doc/bitbake-user-manual/bitbake-user-manual-execution.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-execution.xml
@@ -265,8 +265,8 @@
             with <filename>BBFILES</filename> and stores the values of
             various variables into the datastore.
             <note>
-                Append files are applied in the order they are encountered in
-                <filename>BBFILES</filename>.
+                <para>Append files are applied in the order they are encountered in
+                <filename>BBFILES</filename>.</para>
             </note>
             For each file, a fresh copy of the base configuration is
             made, then the recipe is parsed line by line.
@@ -344,10 +344,10 @@
     BBFILE_PRIORITY_local = "10"
             </literallayout>
             <note>
-                The layers mechanism is now the preferred method of collecting
+                <para>The layers mechanism is now the preferred method of collecting
                 code.
                 While the collections code remains, its main use is to set layer
-                priorities and to deal with overlap (conflicts) between layers.
+                priorities and to deal with overlap (conflicts) between layers.</para>
             </note>
         </para>
     </section>
@@ -582,9 +582,9 @@
         </para>
 
         <note>
-            Some tasks are marked as "nostamp" tasks.
+            <para>Some tasks are marked as "nostamp" tasks.
             No timestamp file is created when these tasks are run.
-            Consequently, "nostamp" tasks are always rerun.
+            Consequently, "nostamp" tasks are always rerun.</para>
         </note>
 
         <para>
@@ -817,9 +817,9 @@
             to determine the stamps and delta where these two
             stamp trees diverge.
             <note>
-                It is likely that future versions of BitBake will
+                <para>It is likely that future versions of BitBake will
                 provide other signature handlers triggered through
-                additional "-S" parameters.
+                additional "-S" parameters.</para>
             </note>
         </para>
 

--- a/doc/bitbake-user-manual/bitbake-user-manual-execution.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-execution.xml
@@ -1,5 +1,5 @@
-<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
 <chapter id="bitbake-user-manual-execution">
     <title>Execution</title>

--- a/doc/bitbake-user-manual/bitbake-user-manual-fetching.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-fetching.xml
@@ -58,10 +58,10 @@
             This code unpacks the downloaded files to the
             specified by <filename>WORKDIR</filename>.
             <note>
-                For convenience, the naming in these examples matches
+                <para>For convenience, the naming in these examples matches
                 the variables used by OpenEmbedded.
                 If you want to see the above code in action, examine
-                the OpenEmbedded class file <filename>base.bbclass</filename>.
+                the OpenEmbedded class file <filename>base.bbclass</filename>.</para>
             </note>
             The <filename>SRC_URI</filename> and <filename>WORKDIR</filename>
             variables are not hardcoded into the fetcher, since those fetcher
@@ -177,8 +177,8 @@
             BitBake uses this stamp during subsequent builds to avoid
             downloading or comparing a checksum for the file again.
             <note>
-                It is assumed that local storage is safe from data corruption.
-                If this were not the case, there would be bigger issues to worry about.
+                <para>It is assumed that local storage is safe from data corruption.
+                If this were not the case, there would be bigger issues to worry about.</para>
             </note>
         </para>
 
@@ -272,10 +272,10 @@
                 <link linkend='var-FILESDIR'><filename>FILESDIR</filename></link>
                 is used to find the appropriate relative file.
                 <note>
-                    <filename>FILESDIR</filename> is deprecated and can
+                    <para><filename>FILESDIR</filename> is deprecated and can
                     be replaced with <filename>FILESPATH</filename>.
                     Because <filename>FILESDIR</filename> is likely to be
-                    removed, you should not use this variable in any new code.
+                    removed, you should not use this variable in any new code.</para>
                 </note>
                 If the file cannot be found, it is assumed that it is available in
                 <link linkend='var-DL_DIR'><filename>DL_DIR</filename></link>
@@ -326,20 +326,20 @@
                 </literallayout>
             </para>
             <note>
-               Because URL parameters are delimited by semi-colons, this can
+               <para>Because URL parameters are delimited by semi-colons, this can
                introduce ambiguity when parsing URLs that also contain semi-colons,
-               for example:
+               for example:</para>
                 <literallayout class='monospaced'>
      SRC_URI = "http://abc123.org/git/?p=gcc/gcc.git;a=snapshot;h=a5dd47"
                 </literallayout>
-               Such URLs should should be modified by replacing semi-colons with '&amp;' characters:
+               <para>Such URLs should should be modified by replacing semi-colons with '&amp;' characters:</para>
                <literallayout class='monospaced'>
      SRC_URI = "http://abc123.org/git/?p=gcc/gcc.git&amp;a=snapshot&amp;h=a5dd47"
                 </literallayout>
-                In most cases this should work. Treating semi-colons and '&amp;' in queries
+                <para>In most cases this should work. Treating semi-colons and '&amp;' in queries
                 identically is recommended by the World Wide Web Consortium (W3C).
                 Note that due to the nature of the URL, you may have to specify the name
-                of the downloaded file as well:
+                of the downloaded file as well:</para>
               <literallayout class='monospaced'>
      SRC_URI = "http://abc123.org/git/?p=gcc/gcc.git&amp;a=snapshot&amp;h=a5dd47;downloadfilename=myfile.bz2"
                 </literallayout>
@@ -667,13 +667,13 @@
                         The module, which must include the
                         prepending "/" character, in the selected VOB.
                         <note>
-                            The <filename>module</filename> and <filename>vob</filename>
+                            <para>The <filename>module</filename> and <filename>vob</filename>
                             options are combined to create the <filename>load</filename> rule in
                             the view config spec.
                             As an example, consider the <filename>vob</filename> and 
                             <filename>module</filename> values from the 
                             <filename>SRC_URI</filename> statement at the start of this section.
-                            Combining those values results in the following:
+                            Combining those values results in the following:</para>
                             <literallayout class='monospaced'>
      load /example_vob/example_module
                             </literallayout>
@@ -692,11 +692,11 @@
                 use the <filename>CCASE_CUSTOM_CONFIG_SPEC</filename> variable
                 in your recipe to define where the specification is written.
                 <note>
-                    the <filename>SRCREV</filename> loses its functionality if you
+                    <para>the <filename>SRCREV</filename> loses its functionality if you
                     specify this variable.
                     However, <filename>SRCREV</filename> is still used to label the
                     archive after a fetch even though it does not define what is
-                    fetched.
+                    fetched.</para>
                 </note>
             </para>
 

--- a/doc/bitbake-user-manual/bitbake-user-manual-fetching.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-fetching.xml
@@ -1,5 +1,5 @@
-<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
 <chapter>
 <title>File Download Support</title>

--- a/doc/bitbake-user-manual/bitbake-user-manual-hello.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-hello.xml
@@ -1,5 +1,5 @@
-<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+<!DOCTYPE appendix PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
 <appendix id='hello-world-example'>
     <title>Hello World Example</title>

--- a/doc/bitbake-user-manual/bitbake-user-manual-hello.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-hello.xml
@@ -129,7 +129,7 @@
         </para>
 
         <note>
-            This example was inspired by and drew heavily from these sources:
+            <para>This example was inspired by and drew heavily from these sources:</para>
             <itemizedlist>
                 <listitem><para>
                     <ulink url="http://www.mail-archive.com/yocto@yoctoproject.org/msg09379.html">Mailing List post - The BitBake equivalent of "Hello, World!"</ulink>
@@ -228,9 +228,9 @@
                 BitBake uses that directory to find the metadata it needs for
                 your project.
                 <note>
-                    When specifying your project directory, do not use the
+                    <para>When specifying your project directory, do not use the
                     tilde ("~") character as BitBake does not expand that character
-                    as the shell would.
+                    as the shell would.</para>
                 </note>
                 </para></listitem>
             <listitem><para><emphasis>Run Bitbake:</emphasis>
@@ -294,10 +294,10 @@
                 Here, the <filename>TMPDIR</filename> directory is set to
                 <filename>hello/tmp</filename>.
                 <note><title>Tip</title>
-                    You can always safely delete the <filename>tmp</filename>
+                    <para>You can always safely delete the <filename>tmp</filename>
                     directory in order to rebuild a BitBake target.
                     The build process creates the directory for you
-                    when you run BitBake.
+                    when you run BitBake.</para>
                 </note></para>
                 <para>For information about each of the other variables defined in this
                 example, click on the links to take you to the definitions in
@@ -376,8 +376,9 @@ ERROR: Unable to parse base: ParseError in configuration INHERITs: Could not inh
                 code separate from the general metadata used by BitBake.
                 Thus, this example creates and uses a layer called "mylayer".
                 <note>
-                    You can find additional information on adding a layer at
+                    <para>You can find additional information on adding a layer at
                     <ulink url='http://hambedded.org/blog/2012/11/24/from-bitbake-hello-world-to-an-image/#adding-an-example-layer'></ulink>.
+                    </para>
                 </note>
                 </para>
                 <para>Minimally, you need a recipe file and a layer configuration
@@ -483,7 +484,7 @@ ERROR: Unable to parse base: ParseError in configuration INHERITs: Could not inh
                 BitBake finds the <filename>printhello</filename> recipe and
                 successfully runs the task.
                 <note>
-                    After the first execution, re-running
+                    <para>After the first execution, re-running
                     <filename>bitbake printhello</filename> again will not
                     result in a BitBake run that prints the same console
                     output.
@@ -498,7 +499,7 @@ ERROR: Unable to parse base: ParseError in configuration INHERITs: Could not inh
                     If you delete the <filename>tmp</filename> directory
                     or run <filename>bitbake -c clean printhello</filename>
                     and then re-run the build, the "Hello, World!" message will
-                    be printed again.
+                    be printed again.</para>
                 </note>
                 </para></listitem>
         </orderedlist>

--- a/doc/bitbake-user-manual/bitbake-user-manual-intro.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-intro.xml
@@ -231,14 +231,14 @@
                 as its build system, files with the <filename>.bb</filename>
                 extension are referred to as recipes.
                 <note>
-                    The term "package" is also commonly used to describe recipes.
+                    <para>The term "package" is also commonly used to describe recipes.
                     However, since the same word is used to describe packaged
                     output from a project, it is best to maintain a single
                     descriptive term - "recipes".
                     Put another way, a single "recipe" file is quite capable
                     of generating a number of related but separately installable
                     "packages".
-                    In fact, that ability is fairly common.
+                    In fact, that ability is fairly common.</para>
                 </note>
             </para>
         </section>
@@ -421,10 +421,10 @@
                     source code repository gives you access to a known
                     branch or release of BitBake.
                     <note>
-                         Cloning the Git repository, as described earlier,
+                         <para>Cloning the Git repository, as described earlier,
                          is the preferred method for getting BitBake.
                          Cloning the repository makes it easier to update as
-                         patches are added to the stable branches.
+                         patches are added to the stable branches.</para>
                     </note></para>
                     <para>The following example downloads a snapshot of
                     BitBake version 1.17.0:
@@ -583,11 +583,12 @@
      $ bitbake -b foo.bb -c clean
                     </literallayout>
                     <note>
-                        The "-b" option explicitly does not handle recipe
+                      <para>
+                        The <option>-b</option> option explicitly does not handle recipe
                         dependencies.
                         Other than for debugging purposes, it is instead
                         recommended that you use the syntax presented in the
-                        next section.
+                        next section.</para>
                     </note>
                 </para>
             </section>

--- a/doc/bitbake-user-manual/bitbake-user-manual-intro.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-intro.xml
@@ -1,5 +1,5 @@
-<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-    "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+    "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
 <chapter id="bitbake-user-manual-intro">
     <title>Overview</title>

--- a/doc/bitbake-user-manual/bitbake-user-manual-metadata.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-metadata.xml
@@ -1,5 +1,5 @@
-<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
 <chapter id="bitbake-user-manual-metadata">
     <title>Syntax and Operators</title>

--- a/doc/bitbake-user-manual/bitbake-user-manual-metadata.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-metadata.xml
@@ -87,10 +87,10 @@
                 However, if <filename>A</filename> is not set,
                 the variable is set to "aval".
                 <note>
-                    This assignment is immediate.
+                    <para>This assignment is immediate.
                     Consequently, if multiple "?=" assignments
                     to a single variable exist, the first of those ends up getting
-                    used.
+                    used.</para>
                 </note>
             </para>
         </section>
@@ -228,8 +228,8 @@
                 The variable <filename>D</filename> becomes
                 "dvaladditional data".
                 <note>
-                    You must control all spacing when you use the
-                    override syntax.
+                    <para>You must control all spacing when you use the
+                    override syntax.</para>
                 </note>
             </para>
         </section>
@@ -647,9 +647,9 @@
                 <filename>classes/autotools.bbclass</filename>
                 in <filename>BBPATH</filename>.
                 <note>
-                    You can override any values and functions of the
+                    <para>You can override any values and functions of the
                     inherited class within your recipe by doing so
-                    after the "inherit" statement.
+                    after the "inherit" statement.</para>
                 </note>
             </para>
         </section>
@@ -675,14 +675,14 @@
      include test_defs.inc
                 </literallayout>
                 <note>
-                    The <filename>include</filename> directive does not
+                    <para>The <filename>include</filename> directive does not
                     produce an error when the file cannot be found.
                     Consequently, it is recommended that if the file you
                     are including is expected to exist, you should use
                     <link linkend='require-inclusion'><filename>require</filename></link>
                     instead of <filename>include</filename>.
                     Doing so makes sure that an error is produced if the
-                    file cannot be found.
+                    file cannot be found.</para>
                 </note>
             </para>
         </section>
@@ -754,10 +754,10 @@
                 "classes" subdirectory in one of the directories specified
                 in <filename>BBPATH</filename>.
                 <note>
-                    Because <filename>.conf</filename> files are parsed
+                    <para>Because <filename>.conf</filename> files are parsed
                     first during BitBake's execution, using
                     <filename>INHERIT</filename> to inherit a class effectively
-                    inherits the class globally (i.e. for all recipes).
+                    inherits the class globally (i.e. for all recipes).</para>
                 </note>
             </para>
         </section>
@@ -1142,12 +1142,12 @@
      export CCACHE_DIR
                         </literallayout>
                         <note>
-                            A side effect of the previous steps is that BitBake
+                            <para>A side effect of the previous steps is that BitBake
                             records the variable as a dependency of the build process
                             in things like the setscene checksums.
                             If doing so results in unnecessary rebuilds of tasks, you can
                             whitelist the variable so that the setscene code
-                            ignores the dependency when it creates checksums.
+                            ignores the dependency when it creates checksums.</para>
                         </note></para></listitem>
                 </orderedlist>
             </para>
@@ -1485,7 +1485,7 @@
             <link linkend='var-BBVERSIONS'><filename>BBVERSIONS</filename></link>
             variables.
             <note>
-                The mechanism for this class extension is extremely
+                <para>The mechanism for this class extension is extremely
                 specific to the implementation.
                 Usually, the recipe's
                 <link linkend='var-PROVIDES'><filename>PROVIDES</filename></link>,
@@ -1494,7 +1494,7 @@
                 variables would need to be modified by the extension class.
                 For specific examples, see the OE-Core
                 <filename>native</filename>, <filename>nativesdk</filename>,
-                and <filename>multilib</filename> classes.
+                and <filename>multilib</filename> classes.</para>
             </note>
             <itemizedlist>
                 <listitem><para><emphasis><filename>BBCLASSEXTEND</filename>:</emphasis>

--- a/doc/bitbake-user-manual/bitbake-user-manual-ref-variables.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-ref-variables.xml
@@ -13,7 +13,7 @@
 </para>
 
 <note>
-    Following are some points regarding the variables listed in this glossary:
+    <para>Following are some points regarding the variables listed in this glossary:</para>
     <itemizedlist>
         <listitem><para>The variables listed in this glossary
             are specific to BitBake.
@@ -373,8 +373,8 @@
                     and
                     <link linkend='var-BB_ENV_EXTRAWHITE'><filename>BB_ENV_EXTRAWHITE</filename></link>.
                     <note>
-                        You must set this variable in the external environment
-                        in order for it to work.
+                        <para>You must set this variable in the external environment
+                        in order for it to work.</para>
                     </note>
                 </para>
             </glossdef>
@@ -390,8 +390,8 @@
                     set in
                     <link linkend='var-BB_ENV_WHITELIST'><filename>BB_ENV_WHITELIST</filename></link>.
                     <note>
-                        You must set this variable in the external
-                        environment in order for it to work.
+                        <para>You must set this variable in the external
+                        environment in order for it to work.</para>
                     </note>
                 </para>
             </glossdef>
@@ -602,9 +602,9 @@
                     The copy is taken before any whitelisted variable values
                     are filtered into BitBake's datastore.
                     <note>
-                        The contents of this variable is a datastore object
+                        <para>The contents of this variable is a datastore object
                         that can be queried using the normal datastore
-                        operations.
+                        operations.</para>
                     </note>
                 </para>
             </glossdef>
@@ -617,8 +617,8 @@
                     through from the external environment into BitBake's
                     datastore.
                     <note>
-                        You must set this variable in the external
-                        environment in order for it to work.
+                        <para>You must set this variable in the external
+                        environment in order for it to work.</para>
                     </note>
                 </para>
             </glossdef>
@@ -826,8 +826,8 @@
                             </para></listitem>
                     </itemizedlist>
                     <note>
-                        Stamp policies are largely obsolete with the
-                        introduction of setscene tasks.
+                        <para>Stamp policies are largely obsolete with the
+                        introduction of setscene tasks.</para>
                     </note>
                 </para>
             </glossdef>
@@ -866,9 +866,9 @@
                     You can use the <filename>BB_TASK_IONICE_LEVEL</filename>
                     variable to adjust the I/O priority of these tasks.
                     <note>
-                        This variable works similarly to the
+                        <para>This variable works similarly to the
                         <link linkend='var-BB_TASK_NICE_LEVEL'><filename>BB_TASK_NICE_LEVEL</filename></link>
-                        variable except with a task's I/O priorities.
+                        variable except with a task's I/O priorities.</para>
                     </note>
                 </para>
 
@@ -892,12 +892,12 @@
                     You do not need any special privileges to use this range
                     of priority values.
                     <note>
-                        In order for your I/O priority settings to take effect,
+                        <para>In order for your I/O priority settings to take effect,
                         you need the Completely Fair Queuing (CFQ) Scheduler
                         selected for the backing block device.
                         To select the scheduler, use the following command form
                         where <replaceable>device</replaceable> is the device
-                        (e.g. sda, sdb, and so forth):
+                        (e.g. sda, sdb, and so forth):</para>
                         <literallayout class='monospaced'>
       $ sudo sh -c “echo cfq > /sys/block/<replaceable>device</replaceable>/queu/scheduler
                         </literallayout>
@@ -997,8 +997,8 @@
                     as incremented by the <filename>-d</filename> command line
                     option.
                     <note>
-                        You must set this variable in the external environment
-                        in order for it to work.
+                        <para>You must set this variable in the external environment
+                        in order for it to work.</para>
                     </note>
                 </para>
              </glossdef>
@@ -1049,11 +1049,11 @@
                     more information.
                     The default priority, if unspecified
                     for a layer with no dependencies, is the lowest defined priority + 1
-                    (or 1 if no priorities are defined).</para>
+                    (or 1 if no priorities are defined).
                 <tip>
-                    You can use the command <filename>bitbake-layers show-layers</filename> to list
-                    all configured layers along with their priorities.
-                </tip>
+                    <para>You can use the command <filename>bitbake-layers show-layers</filename> to list
+                    all configured layers along with their priorities.</para>
+                </tip></para>
             </glossdef>
         </glossentry>
 
@@ -1178,9 +1178,9 @@
                     </literallayout>
                     Notice how the vertical bar is used to append the fragments.
                     <note>
-                        When specifying a directory name, use the trailing
+                        <para>When specifying a directory name, use the trailing
                         slash character to ensure you match just that directory
-                        name.
+                        name.</para>
                     </note>
                 </para>
             </glossdef>
@@ -1260,8 +1260,8 @@
                     Using this variable is equivalent to using the
                     <filename>-u</filename> command-line option.
                     <note>
-                        You must set this variable in the external environment
-                        in order for it to work.
+                        <para>You must set this variable in the external environment
+                        in order for it to work.</para>
                     </note>
                 </para>
             </glossdef>
@@ -1326,14 +1326,15 @@
                     of the recipe to build by default in the absence of
                     <filename><link linkend='var-PREFERRED_VERSION'>PREFERRED_VERSION</link></filename>
                     being used to build the development version.
-                </para>
+                
                 <note>
-                    The bias provided by <filename>DEFAULT_PREFERENCE</filename>
+                    <para>The bias provided by <filename>DEFAULT_PREFERENCE</filename>
                     is weak and is overridden by
                     <filename><link linkend='var-BBFILE_PRIORITY'>BBFILE_PRIORITY</link></filename>
                     if that variable is different between two layers
-                    that contain different versions of the same recipe.
+                    that contain different versions of the same recipe.</para>
                 </note>
+                </para>
             </glossdef>
         </glossentry>
 
@@ -1408,16 +1409,17 @@
                 <para>
                     To exclude a recipe from a world build using this variable,
                     set the variable to "1" in the recipe.
-                </para>
+                
 
                 <note>
-                    Recipes added to <filename>EXCLUDE_FROM_WORLD</filename>
+                    <para>Recipes added to <filename>EXCLUDE_FROM_WORLD</filename>
                     may still be built during a world build in order to satisfy
                     dependencies of other recipes.
                     Adding a recipe to <filename>EXCLUDE_FROM_WORLD</filename>
                     only ensures that the recipe is not explicitly added
-                    to the list of build targets in a world build.
+                    to the list of build targets in a world build.</para>
                 </note>
+                </para>
             </glossdef>
         </glossentry>
 
@@ -1528,9 +1530,9 @@
                     was not found using
                     <link linkend='var-FILESPATH'><filename>FILESPATH</filename></link>.
                     <note>
-                        The <filename>FILESDIR</filename> variable is
+                        <para>The <filename>FILESDIR</filename> variable is
                         deprecated and you should use
-                        <filename>FILESPATH</filename> in all new code.
+                        <filename>FILESPATH</filename> in all new code.</para>
                     </note>
                 </para>
             </glossdef>

--- a/doc/bitbake-user-manual/bitbake-user-manual-ref-variables.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-ref-variables.xml
@@ -1,5 +1,5 @@
-<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd"
+<!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"
 [<!ENTITY % poky SYSTEM "../poky.ent"> %poky; ] >
 
 <!-- Dummy chapter -->

--- a/doc/bitbake-user-manual/bitbake-user-manual.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual.xml
@@ -15,18 +15,25 @@
             </imageobject>
         </mediaobject>
 
-        <title>
-            BitBake User Manual
-        </title>
+        <title>BitBake User Manual</title>
 
         <authorgroup>
-            <author>
-                <firstname>Richard Purdie, Chris Larson, and </firstname> <surname>Phil Blundell</surname>
-                <affiliation>
-                    <orgname>BitBake Community</orgname>
-                </affiliation>
-                <email>bitbake-devel@lists.openembedded.org</email>
-            </author>
+          <author>
+            <firstname>Richard</firstname>
+            <surname>Purdie</surname>
+            <affiliation>
+                <orgname>BitBake Community</orgname>
+            </affiliation>
+            <email>bitbake-devel@lists.openembedded.org</email>
+          </author>
+          <author>
+            <firstname>Chris</firstname>
+            <surname>Larson</surname>
+          </author>
+          <author>
+            <firstname>Phil</firstname>
+            <surname>Blundell</surname>
+          </author>
         </authorgroup>
 
 <!--

--- a/doc/bitbake-user-manual/bitbake-user-manual.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual.xml
@@ -1,9 +1,8 @@
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
 <book id='bitbake-user-manual' lang='en'
         xmlns:xi="http://www.w3.org/2003/XInclude"
-        xmlns="http://docbook.org/ns/docbook"
         >
     <bookinfo>
 

--- a/doc/bitbake-user-manual/bitbake-user-manual.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual.xml
@@ -1,9 +1,7 @@
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
 
-<book id='bitbake-user-manual' lang='en'
-        xmlns:xi="http://www.w3.org/2003/XInclude"
-        >
+<book id='bitbake-user-manual' lang='en'>
     <bookinfo>
 
         <mediaobject>
@@ -79,16 +77,16 @@
         </legalnotice>
     </bookinfo>
 
-    <xi:include href="bitbake-user-manual-intro.xml"/>
+    <xi:include href="bitbake-user-manual-intro.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 
-    <xi:include href="bitbake-user-manual-execution.xml"/>
+    <xi:include href="bitbake-user-manual-execution.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 
-    <xi:include href="bitbake-user-manual-metadata.xml"/>
+    <xi:include href="bitbake-user-manual-metadata.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 
-    <xi:include href="bitbake-user-manual-fetching.xml"/>
+    <xi:include href="bitbake-user-manual-fetching.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 
-    <xi:include href="bitbake-user-manual-ref-variables.xml"/>
+    <xi:include href="bitbake-user-manual-ref-variables.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 
-    <xi:include href="bitbake-user-manual-hello.xml"/>
+    <xi:include href="bitbake-user-manual-hello.xml" xmlns:xi="http://www.w3.org/2003/XInclude"/>
 
 </book>


### PR DESCRIPTION
I found several issues in the documentation.  The following bugs are fixed with this pull request:
#### Bugfixes
- Fixed a mixture of DocBook 4 and DocBook 5. You don't need the DocBook 5 namespace inside DB4 documents
- Used throughout the document version 4.5. This is the latest release and there is no reason to use the very old 4.2 anymore. Version 4.5 is backward compatible with 4.2.
- Moved XInclude namespace from root element into the `xi:include` element itself. Avoids validation errors.
- Added several missing `para` elements inside `note` and `tip` elements. You can't start text with `note`, you always need a `para` element.
- Checked validation with the following command:
  
  ```
  $ xmllint --noout --xinclude --postvalid doc/bitbake-user-manual/bitbake-user-manual.xml
  ```
#### Recommendations

I would recommend several other things which is not covered with this pull request (as it may be further discussion):
- Use `screen` or `programlisting` instead of `literallayout`. The latter is more useful for lyrics instead of text for computer inputs and outputs.
- Don't indent the content of `literallayout`. This is a bad idea as indendation can be added by stylesheets. Always start at column one.
- Don't mix block element and inline elements. The `para` element should only contain text and inline elements (like filename or links). Block elements like lists, admonitions, etc. should be placed _outside_ of `para`.
- Use `option` for options. :grin: 
- Always(!) validate your document with the above command to avoid any rendering issues.

Have fun!
