### PR TITLE
lib/bb/fetch2/git.py: added handling of password

### DIFF
--- a/lib/bb/fetch2/git.py
+++ b/lib/bb/fetch2/git.py
@@ -523,7 +523,10 @@ class Git(FetchMethod):
         Return the repository URL
         """
         if ud.user:
-            username = ud.user + '@'
+            if us.pswd:
+                username = ud.user + ':' + us.pswd + '@'
+            else:
+                username = ud.user + '@'
         else:
             username = ""
         return "%s://%s%s%s" % (ud.proto, username, ud.host, ud.path)


### PR DESCRIPTION
I had problems in yocto trying to download a password protected git repository hosted via http.

Tracking down the problem, I noticed that the git fetcher of bitbake only handles the password, but drops the password. This is the change that fixed the problem for me. I hope it will be of use for others as well.