### PR TITLE
bitbake-user-manual: Addeds support for the repo Fetcher

### DIFF
--- a/doc/bitbake-user-manual/bitbake-user-manual-fetching.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-fetching.xml
@@ -777,6 +777,40 @@
             </para>
         </section>
 
+        <section id='repo-fetcher'>
+            <title>Repo Fetcher (<filename>repo://</filename>)</title>
+
+            <para>
+                This fetcher submodule fetches code from google-repo
+                source control system.
+                The fetcher work by initiating and syncing sources of the
+                repo into
+                <link linkend='var-REPODIR'><filename>REPODIR</filename></link>,
+                which is usually
+                <filename><link linkend='var-DL_DIR'>DL_DIR</link>/repo</filename>.
+            </para>
+
+            <para>
+                This fetcher support the following parameters:
+                <itemizedlist>
+                    <listitem><para><emphasis>"protocol":</emphasis>
+                        Protocol to fetch the repo manifest (default: git).
+                        </para></listitem>
+                    <listitem><para><emphasis>"branch":</emphasis>
+                        Branch or tag of repository to get (default: master).
+                        </para></listitem>
+                    <listitem><para><emphasis>"manifest":</emphasis>
+                        Name of the manifest file (default: default.xml).
+                        </para></listitem>
+                </itemizedlist>
+                Some example URLs are as follows:
+                <literallayout class='monospaced'>
+    SRC_URI = "repo://REPOROOT;protocol=git;branch=some_branch;manifest=my_manifest.xml"
+    SRC_URI = "repo://REPOROOT;protocol=file;branch=some_branch;manifest=my_manifest.xml"
+                </literallayout>
+            </para>
+        </section>
+
         <section id='other-fetchers'>
             <title>Other Fetchers</title>
 
@@ -794,9 +828,6 @@
                         </para></listitem>
                     <listitem><para>
                         Secure Shell (<filename>ssh://</filename>)
-                        </para></listitem>
-                    <listitem><para>
-                        Repo (<filename>repo://</filename>)
                         </para></listitem>
                     <listitem><para>
                         OSC (<filename>osc://</filename>)

--- a/doc/bitbake-user-manual/bitbake-user-manual-ref-variables.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-ref-variables.xml
@@ -2089,6 +2089,15 @@
             </glossdef>
         </glossentry>
 
+        <glossentry id='var-REPODIR'><glossterm>REPODIR</glossterm>
+            <glossdef>
+                <para>
+                    The directory in which a local copy of a google-repo
+                    directory is stored when it is synced.
+                </para>
+            </glossdef>
+        </glossentry>
+
         <glossentry id='var-RPROVIDES'><glossterm>RPROVIDES</glossterm>
             <glossdef>
                 <para>


### PR DESCRIPTION
Added a new repo Fetcher section in the same spirit as the existing
sections for other supported fetchers.  Changes included the new section,
removal of the bulleted item that mentioned this fetcher as an
"additional" fetcher, and the creation of a new variable in the glossary
named REPODIR.

Signed-off-by: Nicolas Cornu <nicolac76@yahoo.fr>