### PR TITLE
bitbake-user-manual: document git usehead argument

### DIFF
--- a/doc/bitbake-user-manual/bitbake-user-manual-fetching.xml
+++ b/doc/bitbake-user-manual/bitbake-user-manual-fetching.xml
@@ -588,6 +588,11 @@
                         The name of the path in which to place the checkout.
                         By default, the path is <filename>git/</filename>.
                         </para></listitem>
+                   <listitem><para><emphasis>"usehead":</emphasis>
+                        For local git:// urls to use the current branch HEAD
+                        as the revision for use with AUTOREV. Implies nobranch.
+                        Will only work when protocol is "file".
+                        </para></listitem>
                 </itemizedlist>
                 Here are some example URLs:
                 <literallayout class='monospaced'>


### PR DESCRIPTION
usehead functionality is already present, document it.

Signed-off-by: Yong, Jonathan <jonathan.yong@intel.com>