### PR TITLE
Make prune_suffix prune a suffix

### DIFF
--- a/lib/bb/utils.py
+++ b/lib/bb/utils.py
@@ -722,8 +722,8 @@ def prune_suffix(var, suffixes, d):
     # See if var ends with any of the suffixes listed and
     # remove it if found
     for suffix in suffixes:
-        if var.endswith(suffix):
-            return var.replace(suffix, "")
+        if suffix and var.endswith(suffix):
+            return var[:-len(suffix)]
     return var
 
 def mkdirhier(directory):


### PR DESCRIPTION
... instead of replacing a substring that could happen more than once
and not only when it ends with it.

Signed-off-by: Andre Rosa <andre.rosa@lge.com>