### PR TITLE
add verbnote to shell log commands

### DIFF
--- a/lib/bb/build.py
+++ b/lib/bb/build.py
@@ -407,6 +407,8 @@ exit $ret
                     bb.plain(value)
                 elif cmd == 'bbnote':
                     bb.note(value)
+                elif cmd == 'bbverbnote':
+                    bb.verbnote(value)
                 elif cmd == 'bbwarn':
                     bb.warn(value)
                 elif cmd == 'bberror':


### PR DESCRIPTION
Add the missing bbverbnote fifo cmd for logging from shell.