### PR TITLE
LineFilterProgressHandler: fix parsing line which ends with CR only

### DIFF
--- a/lib/bb/progress.py
+++ b/lib/bb/progress.py
@@ -94,12 +94,15 @@ class LineFilterProgressHandler(ProgressHandler):
         while True:
             breakpos = self._linebuffer.find('\n') + 1
             if breakpos == 0:
-                break
+                # for the case when the line with progress ends with only '\r'
+                breakpos = self._linebuffer.find('\r') + 1
+                if breakpos == 0:
+                    break
             line = self._linebuffer[:breakpos]
             self._linebuffer = self._linebuffer[breakpos:]
             # Drop any line feeds and anything that precedes them
             lbreakpos = line.rfind('\r') + 1
-            if lbreakpos:
+            if lbreakpos and lbreakpos != breakpos:
                 line = line[lbreakpos:]
             if self.writeline(filter_color(line)):
                 super().write(line)


### PR DESCRIPTION
This change fixes the problem with output which ends only with '\r' instead of "\r\n" or "\n". 
Such case I found for S3 fetcher and its aws-cli output for "cp" command:
https://github.com/aws/aws-cli/blob/develop/awscli/customizations/s3/results.py#L520